### PR TITLE
Initializing the HubConnection mHeader variable to an empty HashMap

### DIFF
--- a/signalr-client-sdk/src/microsoft/aspnet/signalr/client/Connection.java
+++ b/signalr-client-sdk/src/microsoft/aspnet/signalr/client/Connection.java
@@ -7,6 +7,7 @@ See License.txt in the project root for license information.
 package microsoft.aspnet.signalr.client;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.gson.Gson;
@@ -46,7 +47,7 @@ public class Connection implements ConnectionBase {
 
     private String mQueryString;
 
-    private Map<String, String> mHeaders;
+    private Map<String, String> mHeaders = new HashMap<String, String>();
 
     private UpdateableCancellableFuture<Void> mConnectionFuture;
 
@@ -542,7 +543,7 @@ public class Connection implements ConnectionBase {
             mConnectionToken = null;
             mCredentials = null;
             mGroupsToken = null;
-            mHeaders = null;
+            mHeaders.clear();
             mMessageId = null;
             mTransport = null;
 

--- a/signalr-client-tests/pom.xml
+++ b/signalr-client-tests/pom.xml
@@ -24,4 +24,16 @@
     </plugins>
   </build>
   <version>1.0.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>microsoft.aspnet.signalr</groupId>
+            <artifactId>signalr-client-sdk</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/signalr-client-tests/src/microsoft/aspnet/signalr/client/tests/mocktransport/HubConnectionTests.java
+++ b/signalr-client-tests/src/microsoft/aspnet/signalr/client/tests/mocktransport/HubConnectionTests.java
@@ -319,6 +319,15 @@ public class HubConnectionTests {
     }
 
     @Test
+    public void setHubConnectionHeaders(){
+        HubConnection connection = new HubConnection(SERVER_URL, "", true, new NullLogger());
+        connection.getHeaders().put("key", "value");
+
+        assertEquals(1, connection.getHeaders().values().size());
+        assertEquals("value", connection.getHeaders().get("key"));
+    }
+
+    @Test
     public void testMultipleSubscriptionForEvent() throws Exception {
 
         MockClientTransport transport = new MockClientTransport();


### PR DESCRIPTION
The HubConnection mHeader variable is not initialized, so it is always null.  Since it is a private variable, it is not possible to ever set the headers.  To get around this, I've initialized mHeader to be an empty HashMap that gets cleared on disconnect.  The unit test shows that you are now able to add headers with this change.  This fixes issue #22.
