### PR TITLE
Fixed hubconnection to properly handle LongPollingTransport connections.

### DIFF
--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/Connection.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/Connection.java
@@ -20,6 +20,7 @@ import microsoft.aspnet.signalr.client.transport.AutomaticTransport;
 import microsoft.aspnet.signalr.client.transport.ClientTransport;
 import microsoft.aspnet.signalr.client.transport.ConnectionType;
 import microsoft.aspnet.signalr.client.transport.DataResultCallback;
+import microsoft.aspnet.signalr.client.transport.HttpClientTransport;
 import microsoft.aspnet.signalr.client.transport.NegotiationResponse;
 import microsoft.aspnet.signalr.client.transport.TransportHelper;
 import microsoft.aspnet.signalr.client.Logger;
@@ -828,5 +829,10 @@ public class Connection implements ConnectionBase {
                 onError(error, false);
             }
         }
+    }
+
+    public Class getTransportClass() {
+        if(mTransport == null) return null;
+        return mTransport.getClass();
     }
 }

--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/hubs/HubConnection.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/hubs/HubConnection.java
@@ -21,6 +21,7 @@ import microsoft.aspnet.signalr.client.InvalidStateException;
 import microsoft.aspnet.signalr.client.LogLevel;
 import microsoft.aspnet.signalr.client.Logger;
 import microsoft.aspnet.signalr.client.Connection;
+import microsoft.aspnet.signalr.client.transport.LongPollingTransport;
 
 /**
  * Represents a SignalRConnection that implements the Hubs protocol
@@ -74,7 +75,8 @@ public class HubConnection extends Connection {
         super.onReceived(message);
 
         log("Processing message", LogLevel.Information);
-        if (getState() == ConnectionState.Connected) {
+        ConnectionState state = getState();
+        if (state == ConnectionState.Connected || (getTransportClass().equals(LongPollingTransport.class) && (state == ConnectionState.Connected || state == ConnectionState.Reconnecting))) {
             if (message.isJsonObject() && message.getAsJsonObject().has("I")) {
                 log("Getting HubResult from message", LogLevel.Verbose);
                 HubResult result = mGson.fromJson(message, HubResult.class);


### PR DESCRIPTION
I had problems with LongPollingTransport which prevented the java-client to call subscription methods. Because for LongPollingTransport it is normal behaviour to be in Reconnecting state, the incoming data should be processed as well when the connection is in this state.
