### PR TITLE
Fix to issue #75 to handle multi-frame websocket messages

### DIFF
--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/Connection.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/Connection.java
@@ -207,6 +207,11 @@ public class Connection implements ConnectionBase {
     public void setGroupsToken(String groupsToken) {
         mGroupsToken = groupsToken;
     }
+    
+    @Override
+    public void addHeader(String headerName, String headerValue) {
+        mHeaders.put(headerName, headerValue);
+    }
 
     @Override
     public Map<String, String> getHeaders() {

--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/ConnectionBase.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/ConnectionBase.java
@@ -169,6 +169,11 @@ public interface ConnectionBase {
      * Returns the connection headers
      */
     Map<String, String> getHeaders();
+    
+    /**
+     * Add a header
+     */
+    void addHeader(String headerName, String headerValue);
 
     /**
      * Returns the Gson instance used by the connection

--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/http/InvalidHttpStatusCodeException.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/http/InvalidHttpStatusCodeException.java
@@ -13,7 +13,15 @@ public class InvalidHttpStatusCodeException extends Exception {
 
     private static final long serialVersionUID = 7073157073424850921L;
 
+    private final int mStatusCode;
+
     public InvalidHttpStatusCodeException(int statusCode, String responseContent, String responseHeaders) {
         super("Invalid status code: " + statusCode + "\nResponse: " + responseContent + "\nHeaders: " + responseHeaders);
+
+        mStatusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return mStatusCode;
     }
 }

--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/HttpClientTransport.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/HttpClientTransport.java
@@ -61,6 +61,7 @@ public abstract class HttpClientTransport implements ClientTransport {
 
         Request get = new Request(Constants.HTTP_GET);
         get.setUrl(url);
+        get.setHeaders(connection.getHeaders());
         get.setVerb(Constants.HTTP_GET);
 
         connection.prepareRequest(get);

--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/WebsocketTransport.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/WebsocketTransport.java
@@ -6,14 +6,18 @@ See License.txt in the project root for license information.
 
 package microsoft.aspnet.signalr.client.transport;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 
+import javax.net.ssl.SSLSocketFactory;
+
 import com.google.gson.Gson;
 
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft_17;
 import org.java_websocket.exceptions.InvalidDataException;
 import org.java_websocket.framing.Framedata;
 import org.java_websocket.handshake.ServerHandshake;
@@ -65,7 +69,7 @@ public class WebsocketTransport extends HttpClientTransport {
         final String groupsToken = connection.getGroupsToken() != null ? connection.getGroupsToken() : "";
         final String connectionData = connection.getConnectionData() != null ? connection.getConnectionData() : "";
 
-
+        boolean isSsl = false;
         String url = null;
         try {
             url = connection.getUrl() + "signalr/" + connectionString + '?'
@@ -74,6 +78,15 @@ public class WebsocketTransport extends HttpClientTransport {
                     + "&groupsToken=" + URLEncoder.encode(groupsToken, "UTF-8")
                     + "&messageId=" + URLEncoder.encode(messageId, "UTF-8")
                     + "&transport=" + URLEncoder.encode(transport, "UTF-8");
+            if(connection.getQueryString() != null) {
+            	url += "&" + connection.getQueryString();
+            }
+            if(url.startsWith("https://")){
+            	isSsl = true;
+            	url = url.replace("https://", "wss://");
+            } else if(url.startsWith("http://")){
+            	url = url.replace("http://", "ws://");
+            }
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
@@ -89,7 +102,7 @@ public class WebsocketTransport extends HttpClientTransport {
             return mConnectionFuture;
         }
 
-        mWebSocketClient = new WebSocketClient(uri) {
+        mWebSocketClient = new WebSocketClient(uri,new Draft_17(), connection.getHeaders(), 0) {
             @Override
             public void onOpen(ServerHandshake serverHandshake) {
                 mConnectionFuture.setResult(null);
@@ -108,6 +121,7 @@ public class WebsocketTransport extends HttpClientTransport {
             @Override
             public void onError(Exception e) {
                 mWebSocketClient.close();
+                mConnectionFuture.triggerError(e);
             }
 
             @Override
@@ -141,6 +155,15 @@ public class WebsocketTransport extends HttpClientTransport {
                 }
             }
         };
+        
+        if(isSsl){
+        	SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+            try {
+            mWebSocketClient.setSocket(factory.createSocket());
+            } catch (IOException e1) {
+                e1.printStackTrace();
+            }
+        }
         mWebSocketClient.connect();
 
         connection.closed(new Runnable() {

--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/WebsocketTransport.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/WebsocketTransport.java
@@ -14,8 +14,6 @@ import java.net.URLEncoder;
 
 import javax.net.ssl.SSLSocketFactory;
 
-import com.google.gson.Gson;
-
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft_17;
 import org.java_websocket.exceptions.InvalidDataException;
@@ -36,8 +34,8 @@ import microsoft.aspnet.signalr.client.http.HttpConnection;
  */
 public class WebsocketTransport extends HttpClientTransport {
 
-    private String mPrefix;
-    private static final Gson gson = new Gson();
+    private StringBuffer mBuffer = new StringBuffer();
+
     WebSocketClient mWebSocketClient;
     private UpdateableCancellableFuture<Void> mConnectionFuture;
 
@@ -127,28 +125,21 @@ public class WebsocketTransport extends HttpClientTransport {
             @Override
             public void onFragment(Framedata frame) {
                 try {
+
+                    // read all data as UTF-8
                     String decodedString = Charsetfunctions.stringUtf8(frame.getPayloadData());
 
-                    if(decodedString.equals("]}")){
-                        return;
-                    }
+                    // add string to buffer
+                    mBuffer.append(decodedString);
 
-                    if(decodedString.endsWith(":[") || null == mPrefix){
-                        mPrefix = decodedString;
-                        return;
-                    }
+                    // if this is final frame
+                    if(frame.isFin()) {
+                        String message = mBuffer.toString();
 
-                    String simpleConcatenate = mPrefix + decodedString;
+                        // reset buffer
+                        mBuffer = new StringBuffer();
 
-                    if(isJSONValid(simpleConcatenate)){
-                        onMessage(simpleConcatenate);
-                    }else{
-                        String extendedConcatenate = simpleConcatenate + "]}";
-                        if (isJSONValid(extendedConcatenate)) {
-                            onMessage(extendedConcatenate);
-                        } else {
-                            log("invalid json received:" + decodedString, LogLevel.Critical);
-                        }
+                        onMessage(message);
                     }
                 } catch (InvalidDataException e) {
                     e.printStackTrace();
@@ -159,7 +150,7 @@ public class WebsocketTransport extends HttpClientTransport {
         if(isSsl){
         	SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
             try {
-            mWebSocketClient.setSocket(factory.createSocket());
+                mWebSocketClient.setSocket(factory.createSocket());
             } catch (IOException e1) {
                 e1.printStackTrace();
             }
@@ -180,14 +171,5 @@ public class WebsocketTransport extends HttpClientTransport {
     public SignalRFuture<Void> send(ConnectionBase connection, String data, DataResultCallback callback) {
         mWebSocketClient.send(data);
         return new UpdateableCancellableFuture<Void>(null);
-    }
-
-    private boolean isJSONValid(String test){
-        try {
-            gson.fromJson(test, Object.class);
-            return true;
-        } catch(com.google.gson.JsonSyntaxException ex) {
-            return false;
-        }
     }
 }

--- a/signalr-client-tests/src/main/java/microsoft/aspnet/signalr/client/tests/mocktransport/CustomSerializationTests.java
+++ b/signalr-client-tests/src/main/java/microsoft/aspnet/signalr/client/tests/mocktransport/CustomSerializationTests.java
@@ -126,9 +126,48 @@ public class CustomSerializationTests {
     @Test
     public void testTimeParse() throws Exception {
 
-        assertNotNull(DateSerializer.deserialize("2014-03-29T00:00:00"));
-        assertNotNull(DateSerializer.deserialize("2014-03-29T00:00:00Z"));
-        assertNotNull(DateSerializer.deserialize("2014-03-29T00:00:00+00:00"));
-        assertNotNull(DateSerializer.deserialize("2014-03-29T00:00:00.Z"));
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        calendar.set(2014, 3 - 1, 29, 12, 34, 56);
+
+        calendar.set(Calendar.MILLISECOND, 0);
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56."));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56Z"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.Z"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56+00:00"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.+00:00"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T04:04:56-08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T04:04:56.-08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T21:04:56+08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T21:04:56.+08:30"));
+
+        calendar.set(Calendar.MILLISECOND, 700);
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.7"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.7Z"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.7+00:00"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T04:04:56.7-08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T21:04:56.7+08:30"));
+
+        calendar.set(Calendar.MILLISECOND, 780);
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.78"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.78Z"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.78+00:00"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T04:04:56.78-08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T21:04:56.78+08:30"));
+
+        calendar.set(Calendar.MILLISECOND, 789);
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.789"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.789Z"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.789+00:00"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T04:04:56.789-08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T21:04:56.789+08:30"));
+
+        calendar.set(Calendar.MILLISECOND, 789);
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.7891"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.7891Z"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T12:34:56.7891+00:00"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T04:04:56.7891-08:30"));
+        assertEquals(calendar.getTime(), DateSerializer.deserialize("2014-03-29T21:04:56.7891+08:30"));
     }
 }


### PR DESCRIPTION
The WebSocket Fragment Handler assumes that it is always receiving a JSON formatted string. This has bugs when receiving multiple frames.

When receiving frames, the transport should accept all messages until the final frame is received.
It is SignalR's responsibility, not the transport, to determine if the received message is valid.

This should fix Issue #75 and #104 