### PR TITLE
fix ConcurrentModificationException at SignalRFuture

### DIFF
--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/SignalRFuture.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/SignalRFuture.java
@@ -6,10 +6,10 @@ See License.txt in the project root for license information.
 
 package microsoft.aspnet.signalr.client;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
@@ -23,10 +23,10 @@ public class SignalRFuture<V> implements Future<V> {
     boolean mIsCancelled = false;
     boolean mIsDone = false;
     private V mResult = null;
-    private List<Runnable> mOnCancelled = new ArrayList<Runnable>();
-    private List<Action<V>> mOnDone = new ArrayList<Action<V>>();
+    private List<Runnable> mOnCancelled = new CopyOnWriteArrayList<>();
+    private List<Action<V>> mOnDone = new CopyOnWriteArrayList<Action<V>>();
     private Object mDoneLock = new Object();
-    private List<ErrorCallback> mErrorCallback = new ArrayList<ErrorCallback>();
+    private List<ErrorCallback> mErrorCallback = new CopyOnWriteArrayList<ErrorCallback>();
     private Queue<Throwable> mErrorQueue = new ConcurrentLinkedQueue<Throwable>();
     private Object mErrorLock = new Object();
     private Throwable mLastError = null;
@@ -35,7 +35,7 @@ public class SignalRFuture<V> implements Future<V> {
 
     /**
      * Handles the cancellation event
-     * 
+     *
      * @param onCancelled
      *            The handler
      */
@@ -58,7 +58,7 @@ public class SignalRFuture<V> implements Future<V> {
 
     /**
      * Sets a result to the future and finishes its execution
-     * 
+     *
      * @param result
      *            The future result
      */
@@ -83,7 +83,7 @@ public class SignalRFuture<V> implements Future<V> {
 
     /**
      * Indicates if the operation is cancelled
-     * 
+     *
      * @return True if the operation is cancelled
      */
     public boolean isCancelled() {
@@ -128,7 +128,7 @@ public class SignalRFuture<V> implements Future<V> {
     /**
      * Handles the completion of the Future. If the future was already
      * completed, it triggers the handler right away.
-     * 
+     *
      * @param action
      *            The handler
      */
@@ -152,7 +152,7 @@ public class SignalRFuture<V> implements Future<V> {
      * Handles error during the execution of the Future. If it's the first time
      * the method is invoked on the object and errors were already triggered,
      * the handler will be called once per error, right away.
-     * 
+     *
      * @param errorCallback
      *            The handler
      */
@@ -172,7 +172,7 @@ public class SignalRFuture<V> implements Future<V> {
 
     /**
      * Triggers an error for the Future
-     * 
+     *
      * @param error
      *            The error
      */
@@ -189,10 +189,10 @@ public class SignalRFuture<V> implements Future<V> {
             }
         }
     }
-    
+
     /**
      * Indicates if an error was triggered
-     * 
+     *
      * @return True if an error was triggered
      */
     public boolean errorWasTriggered() {


### PR DESCRIPTION
Error stack trace  

``````
java.util.ConcurrentModificationException
       at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
       at microsoft.aspnet.signalr.client.SignalRFuture.cancel(SignalRFuture.java:52)
       at microsoft.aspnet.signalr.client.UpdateableCancellableFuture.cancel(UpdateableCancellableFuture.java:39)
       at microsoft.aspnet.signalr.client.Connection.disconnect(Connection.java:532)
       at microsoft.aspnet.signalr.client.Connection.onError(Connection.java:768)
       at microsoft.aspnet.signalr.client.Connection$2.onError(Connection.java:325)
       at microsoft.aspnet.signalr.client.SignalRFuture.triggerError(SignalRFuture.java:185)
       at microsoft.aspnet.signalr.client.transport.AutomaticTransport$2.onError(AutomaticTransport.java:116)
       at microsoft.aspnet.signalr.client.SignalRFuture.triggerError(SignalRFuture.java:185)
       at microsoft.aspnet.signalr.client.transport.LongPollingTransport$3.onError(LongPollingTransport.java:149)
       at microsoft.aspnet.signalr.client.SignalRFuture.triggerError(SignalRFuture.java:185)
       at microsoft.aspnet.signalr.client.http.java.NetworkRunnable.run(NetworkRunnable.java:92)
       at java.lang.Thread.run(Thread.java:841)```
``````
